### PR TITLE
[Dialog, Drawer]: Remove tests to check if not in portal.

### DIFF
--- a/src/dialog/tests/dialog.test.tsx
+++ b/src/dialog/tests/dialog.test.tsx
@@ -5,30 +5,9 @@ import { Button } from '../../button';
 import '@testing-library/jest-dom/extend-expect';
 
 describe('Dialog', () => {
-  test('should not be in portal when closed', () => {
-    const { getByTestId } = render(
-      <Dialog
-        isOpen={false}
-        title="Dialog title"
-        onRequestClose={() => {}}>
-        <div title="insideDialog" />
-      </Dialog>,
-    );
-
-    const portal = getByTestId('kenobi-portal');
-    const dialog: HTMLElement | null = document.querySelector(
-      '[data-testid="kenobi-dialog"]',
-    );
-
-    expect(portal).not.toContainElement(dialog);
-  });
-
   test('should be in portal when open', () => {
     const { getByTestId } = render(
-      <Dialog
-        isOpen={true}
-        title="Dialog title"
-        onRequestClose={() => {}}>
+      <Dialog isOpen={true} title="Dialog title" onRequestClose={() => {}}>
         <div title="insideDialog" />
       </Dialog>,
     );
@@ -43,10 +22,7 @@ describe('Dialog', () => {
 
   test('close button has focus when first opened', () => {
     const { getByTestId } = render(
-      <Dialog
-        isOpen={true}
-        title="Dialog title"
-        onRequestClose={() => {}}>
+      <Dialog isOpen={true} title="Dialog title" onRequestClose={() => {}}>
         <div title="insideDialog" />
       </Dialog>,
     );
@@ -56,10 +32,7 @@ describe('Dialog', () => {
 
   test('can focus another element', () => {
     const { getByTestId } = render(
-      <Dialog
-        isOpen={true}
-        title="Dialog title"
-        onRequestClose={() => {}}>
+      <Dialog isOpen={true} title="Dialog title" onRequestClose={() => {}}>
         <Button data-autofocus>Hello</Button>
       </Dialog>,
     );

--- a/src/drawer/tests/drawer.test.tsx
+++ b/src/drawer/tests/drawer.test.tsx
@@ -5,21 +5,6 @@ import { Button } from '../../button';
 import '@testing-library/jest-dom/extend-expect';
 
 describe('Drawer', () => {
-  test('should not be in portal when closed', () => {
-    const { getByTestId } = render(
-      <Drawer isOpen={false} onRequestClose={() => {}}>
-        Content
-      </Drawer>,
-    );
-
-    const portal = getByTestId('kenobi-portal');
-    const drawer: HTMLElement | null = document.querySelector(
-      '[data-testid="kenobi-drawer"]',
-    );
-
-    expect(portal).not.toContainElement(drawer);
-  });
-
   test('should be in portal when open', () => {
     const { getByTestId } = render(
       <Drawer isOpen={true} onRequestClose={() => {}}>


### PR DESCRIPTION
These tests have been removed because it is no longer possible to test.

The Portal is only in document whenever the children is visible in the document i.e. we cannot get the Portal element by its testid.